### PR TITLE
現在のURL表示

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,5 +12,8 @@
     "default_icon": "images/image_16.png",
     "default_title": "Sample",
     "default_popup": "popup.html"
-  }
+  },
+     "permissions": [
+        "tabs"
+    ]
 }

--- a/popup.html
+++ b/popup.html
@@ -1,1 +1,9 @@
-<h1>test</h1>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<script src="popup.js" type="text/javascript"></script>
+</head>
+<body>
+<div id='url'>
+</div>
+</body>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,8 @@
+window.onload = function() {
+  chrome.tabs.getSelected(window.id, function (tab) {
+    //tab.urlに開いているタブのURLが入っている
+    var url = document.createTextNode(tab.url);
+    document.getElementById('url').appendChild(url); 
+  });
+};
+


### PR DESCRIPTION
【実行環境】
Javascript
【このページでの内容】
chrome拡張機能に現在のURLを表示する機能を追加した。
【実装方法】
参考ページの通り作成した。
「manifest.json」に「permission」でtabsを追加した。
【参考ページ一覧】
http://www.inashiro.com/2011/06/13/dev-chrome-extension-get-current-tab-url/